### PR TITLE
Fix SQL command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ with your values:
 # start psql
 sudo -u postgres psql
 
-CREATE USER "<user>" WITH PASSWORD "<password>";
+CREATE USER "<user>" WITH PASSWORD '<password>';
 CREATE DATABASE "parkapi2" ENCODING=UTF8 OWNER="<user>";
 CREATE DATABASE "parkapi2-test" ENCODING=UTF8 OWNER="<user>";
 


### PR DESCRIPTION
Passwords in SQL commands require single quotes.