### PR TITLE
Improve V1 compatibility

### DIFF
--- a/web/api_v1/views.py
+++ b/web/api_v1/views.py
@@ -179,7 +179,7 @@ class CityLotsView(views.APIView):
                 "address": lot.address,
                 "coords": coords,
                 "forecast": False,  # TODO
-                "free": None,
+                # "free": None, if free is unkown, we don't return it
                 "id": lot.lot_id,
                 "lot_type": LOT_TYPE_MAPPING.get(lot.type, "unbekannt"),
                 "name": lot.name,
@@ -189,9 +189,10 @@ class CityLotsView(views.APIView):
             }
             if lot.latest_data:
                 api_lot.update({
-                    "free": lot.latest_data.num_free,
                     "state": lot.latest_data.status,
                 })
+                if lot.latest_data.num_free is not None:
+                    api_lot["free"] = lot.latest_data.num_free
                 if lot.latest_data.capacity is not None:
                     api_lot["total"] = lot.latest_data.capacity
 

--- a/web/api_v1/views.py
+++ b/web/api_v1/views.py
@@ -131,11 +131,13 @@ class CityMapView(views.APIView):
                     city["attribution"] = None
 
                 lng, lat = loc["geo_point"].tuple
+                source_url = city.pop("source_url")
+                public_url = city.pop("public_url")
                 city.update({
                     "coords": {"lat": lat, "lng": lng},
                     "name": loc["city"],
-                    "url": city.pop("public_url"),
-                    "source": city.pop("source_url"),
+                    "url": public_url,
+                    "source": source_url if source_url else public_url,
                     # TODO: no db-field yet
                     "active_support": False,
                 })

--- a/web/api_v1/views.py
+++ b/web/api_v1/views.py
@@ -187,7 +187,8 @@ class CityLotsView(views.APIView):
                 "name": lot.name,
                 "region": None,  # TODO
                 "state": None,
-                "total": lot.max_capacity,
+                # ParkAPI v1 requires total, so we return 0 if unknown
+                "total": lot.max_capacity if lot.max_capacity else 0,
             }
             if lot.latest_data:
                 api_lot.update({
@@ -209,7 +210,9 @@ class CityLotsView(views.APIView):
 
         return Response({
             "last_downloaded": last_downloaded,
-            "last_updated": last_updated,
+            # v1 schema requires last_updated to be set. If it's not available, 
+            # we fall back to (somewhat misleading) last_downloaded
+            "last_updated": last_updated if last_updated else last_downloaded,
             "lots": api_lot_list,
         })
 

--- a/web/park_api/tests/test_api_v1.py
+++ b/web/park_api/tests/test_api_v1.py
@@ -31,7 +31,8 @@ class TestApiV1(TestBase):
                     "coords": {"lat": 51.6512192, "lng": 7.3393014},
                     "name": "Datteln",
                     "url": "https://www.apag.de",
-                    "source": None,
+                    # Return url as source url, if no explicit source url was defined
+                    "source": "https://www.apag.de",
                     "active_support": False,
                 },
                 "Dresden": {

--- a/web/park_api/tests/test_api_v1.py
+++ b/web/park_api/tests/test_api_v1.py
@@ -74,7 +74,8 @@ class TestApiV1(TestBase):
                         'address': 'An der Frauenkirche 12a\n01067 Dresden\nEinfahrt von Schießgasse\nKontakt: 03 51 / 496 06 03\ntiefgarage-frauenkirche.dresden@gmx.de',
                         'coords': {'lat': 51.051415072, 'lng': 13.7441934672},
                         'forecast': False,
-                        'free': None,
+                        # Don't return free, if not available (to stay backward compatible with ParkAPIv1)
+                        # 'free': None,
                         'id': 'dresdenanderfrauenkirche',
                         'lot_type': 'Tiefgarage',
                         'name': 'An der Frauenkirche',

--- a/web/park_api/urls.py
+++ b/web/park_api/urls.py
@@ -17,13 +17,18 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from django.views.generic.base import RedirectView
 
 from .views import stats
 
 urlpatterns = [
-    path("", stats.StatsView.as_view(), name="stats"),
+    path("stats/", stats.StatsView.as_view(), name="stats"),
     path("admin/", admin.site.urls),
     path("api/", include('park_api.api_urls')),
+    # Maintain API v1 compatibility by redirecting former URLs to new locations
+    path("", RedirectView.as_view(url='api/')),
+    path("<city>", RedirectView.as_view(url='api/%(city)s')),
+    path("<city>/<lot_id>/timespan", RedirectView.as_view(url='api/v1/%(city)s/%(lot_id)s/timespan')),
 ]
 
 if settings.DEBUG is True:


### PR DESCRIPTION
This PR makes some minor adaptations to prepare the api.parkendd.de server switch:

* if `total` is unknown for a lot, the `v1` api returns 0, as total is mandatory 
* if `last_updated` is unknown, we fall back to `last_downloaded`, as `last_updated` is mandatory
* root (`/`) is redirected to `api/`, so current clients accessing `api.parkendd.de` will not break
* `/<city>` requests are redirected to `/api/<city>`, so current clients accessing `api.parkendd.de` will not break
* the page `stats` which is currently served at `/` is moved to `/stats/`
* if no `source_url` is declared, `public_url` is returned, as `source_url` is mandatory.
* `free` is only returned if known (**Note**: while this is conform to the schema, current v1 seems to return 0 if no data is availble, so this might break clients)